### PR TITLE
fix:增加wb-server对用户名和密码的空校验

### DIFF
--- a/weibo/wb-server/src/packets.rs
+++ b/weibo/wb-server/src/packets.rs
@@ -16,8 +16,10 @@ pub struct AjaxResult<T> {
 
 #[derive(Debug, Validate, Deserialize)]
 pub struct LoginPacket {
+    #[validate(length(min = 1, message = "用户名不能为空"))]
     #[validate(length(max = 20, message = "用户名过长"))]
     pub name: String,
+    #[validate(length(min = 1, message = "密码不能为空"))]
     pub pwd: String,
     pub sex: Option<String>,
     pub city: Option<String>,


### PR DESCRIPTION
增加了微博项目对用户名/密码为空时的校验
![image](https://github.com/user-attachments/assets/0b2439b2-a6f0-4380-bd10-7831fa7d16eb)
![image](https://github.com/user-attachments/assets/47f13928-d273-405a-9765-0e8e5fc3fd08)
